### PR TITLE
[TOOLS-4425] do not display CTRL key, including TAB

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -198,9 +198,6 @@ static void tty_show(unsigned char c)
     if (c == DEL) {
         tty_put('^');
         tty_put('?');
-    } else if (ISCTL(c)) {
-        tty_put('^');
-        tty_put(UNCTL(c));
     } else if (rl_meta_chars && ISMETA(c)) {
         tty_put('M');
         tty_put('-');


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4425

**Purpose**
* No action when <TAB> key is pressed

**Implementation**
N/A

**Remarks**
* contribution of @mhoh3963 